### PR TITLE
Reset `model` when `amfHeaders` is set to `undefined`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-headers",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-headers",
   "description": "A library containing elements to support HTTP headers editing supported by the AMF model.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiHeadersEditorElement.js
+++ b/src/ApiHeadersEditorElement.js
@@ -73,7 +73,7 @@ export class ApiHeadersEditorElement extends ApiFormMixin(AmfHelperMixin(Headers
       return;
     }
     this[amfHeadersValue] = value;
-    this.model = this.computeDataModel(value);
+    this.model = value ? this.computeDataModel(value) : [];
     this.apiModel = this.model;
     this.requestUpdate();
     this[notifyValueChange]();

--- a/test/api-headers-editor.test.js
+++ b/test/api-headers-editor.test.js
@@ -233,6 +233,14 @@ x-integer: 0`
           await nextFrame();
           assert.equal(element.value, expected);
         });
+
+        it('should reset model on amfHeaders change to undefined', async () => {
+          const originalModel = element.model;
+          element.amfHeaders = undefined;
+          await nextFrame();
+          assert.isEmpty(element.model);
+          assert.notDeepEqual(element.model, originalModel);
+        });
       });
     });
   });


### PR DESCRIPTION
### Problem
When changing between operations A and B (A having amfHeaders and B not having amfHeaders), headers from the former operation appear in the latter operation. This is occurring because, when the `amfHeaders` property in this component was set to `undefined`, the `model` would remain the same, rather than resetting to an empty array.

### Fix
When setting `amfHeaders` to `undefined`, set the `model` property to an empty array.